### PR TITLE
Apply reattach-to-user-space only on Mac

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -62,7 +62,7 @@ unbind r
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 
 # Patch for OS X pbpaste and pbcopy under tmux.
-set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
+if-shell 'test "$(uname)" = "Darwin"' "set-option -g default-command 'which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL'"
 
 # Local config
 if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'


### PR DESCRIPTION
My tmux was complaining about that patch on Linux.